### PR TITLE
Refactor pages to reuse components

### DIFF
--- a/src/app/notfound/page.tsx
+++ b/src/app/notfound/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Button from "@/components/Button/Button";
 import { motion } from "framer-motion";
 import { Ghost } from "lucide-react";
 import IconWrapper from "@/components/IconWrapper/IconWrapper";
@@ -27,12 +27,9 @@ export default function NotFound() {
         <p className="text-text-secondary mt-2">
           Oops! We couldn`&apos;`t find the page you`&apos;`re looking for.
         </p>
-        <Link
-          href="/"
-          className="mt-6 inline-block px-6 py-3 bg-elements-primary-main text-white rounded-md hover:bg-elements-primary-hover transition"
-        >
+        <Button href="/" type="continue" extraClassNames="mt-6">
           Go Home
-        </Link>
+        </Button>
       </div>
     </PageLayout>
   );

--- a/src/app/servererror/page.tsx
+++ b/src/app/servererror/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import Link from "next/link";
 import { motion } from "framer-motion";
 import { AlertCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 import { TailSpin } from "react-loader-spinner"; // Or your own Spinner
+import Button from "@/components/Button/Button";
+import PageLayout from "@/components/Layouts/PageLayout";
 
 const ErrorIcon = AlertCircle;
 
@@ -27,27 +28,30 @@ export default function ServerErrorPage() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-neutral-dimmed-heavy text-center px-4">
-      <motion.div
-        initial={{ scale: 1 }}
-        animate={{ scale: 1.2 }}
-        transition={{ repeat: Infinity, repeatType: "mirror", duration: 1 }}
-      >
-        <ErrorIcon className="text-[100px] text-elements-secondary-main" />
-      </motion.div>
-      <h1 className="text-4xl font-bold text-text-primary mt-6">
-        500 - Something went wrong
-      </h1>
-      <p className="text-text-secondary mt-2">
-        We`&apos;`re working to fix this. Please try again later or return to
-        the homepage.
-      </p>
-      <Link
-        href="/"
-        className="mt-6 inline-block px-6 py-3 bg-elements-secondary-main text-white rounded-md hover:bg-elements-secondary-hover transition"
-      >
-        Go Home
-      </Link>
-    </div>
+    <PageLayout noPadding fullHeight>
+      <div className="flex flex-col items-center justify-center text-center px-4">
+        <motion.div
+          initial={{ scale: 1 }}
+          animate={{ scale: 1.2 }}
+          transition={{ repeat: Infinity, repeatType: "mirror", duration: 1 }}
+        >
+          <ErrorIcon className="text-[100px] text-elements-secondary-main" />
+        </motion.div>
+        <h1 className="text-4xl font-bold text-text-primary mt-6">
+          500 - Something went wrong
+        </h1>
+        <p className="text-text-secondary mt-2">
+          We`&apos;`re working to fix this. Please try again later or return to
+          the homepage.
+        </p>
+        <Button
+          href="/"
+          type="continue"
+          extraClassNames="mt-6 bg-elements-secondary-main hover:bg-elements-secondary-hover text-white px-6 py-3"
+        >
+          Go Home
+        </Button>
+      </div>
+    </PageLayout>
   );
 }

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { FloatingElement } from "@/components/FloatingElement/FloatingElement";
 import { ServiceCard } from "@/components/ServiceCard/ServiceCard";
+import Button from "@/components/Button/Button";
 
 const Services = () => {
   const [visibleCards, setVisibleCards] = useState(new Set());
@@ -149,10 +150,14 @@ const Services = () => {
         </div>
 
         <div className="text-center mt-20">
-          <div className="inline-flex items-center gap-4 bg-elements-primary-main hover:bg-elements-primary-shadow text-elements-primary-contrastText px-8 py-4 rounded-full font-semibold text-lg shadow-2xl hover:shadow-elements-primary-shadow/25 transform hover:scale-105 transition-all duration-300 cursor-pointer">
+          <Button
+            type="continue"
+            href="/contact"
+            extraClassNames="inline-flex gap-4 px-8 py-4 text-lg shadow-2xl hover:shadow-elements-primary-shadow/25 transform hover:scale-105 group"
+          >
             <span>Ready to bring your vision to life?</span>
-            <ArrowRight className="w-5 h-5 animate-pulse" />
-          </div>
+            <ArrowRight className="w-5 h-5 animate-pulse group-hover:translate-x-1 transition-transform" />
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- swap hardcoded links for Button component
- apply PageLayout to server error page for consistency
- reuse Button in services page CTA

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404ef44368832d91bd6a43882f5cc8