### PR TITLE
Add error modal to web3 contact form

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://makeitlook.co.uk/about</loc><lastmod>2025-06-05T20:19:17.703Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/notfound</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/contact</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/services</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/comingsoon</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/servererror</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/projects</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/projects/beautybar</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/projects/checkmate</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://makeitlook.co.uk/projects/nextgenroofing</loc><lastmod>2025-06-05T20:19:17.704Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/servererror</loc><lastmod>2025-06-06T08:38:55.911Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/about</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/comingsoon</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/contact</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/projects/beautybar</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/projects/checkmate</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/projects/nextgenroofing</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/notfound</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/services</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk/projects</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://makeitlook.co.uk</loc><lastmod>2025-06-06T08:38:55.912Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -49,6 +49,8 @@ const ContactForm: React.FC<FormsProps> = ({
   const [isPrivacyAgreedModalOpen, setIsPrivacyAgreedModalOpen] =
     useState(false);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
+  const [errorModalMessage, setErrorModalMessage] = useState("");
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState("");
   const [toastType, setToastType] = useState<"success" | "error">("success");
@@ -118,6 +120,8 @@ const ContactForm: React.FC<FormsProps> = ({
         error instanceof Error
           ? error.message
           : "An error occurred during submission.";
+      setErrorModalMessage(errorMessage);
+      setIsErrorModalOpen(true);
       setShowToast(true);
       setToastMessage(errorMessage);
       setToastType("error");
@@ -311,6 +315,15 @@ const ContactForm: React.FC<FormsProps> = ({
         title="Submission Successful"
       >
         Thank you for contacting us! We will get back to you shortly.
+      </Modal>
+
+      {/* Error Modal */}
+      <Modal
+        isOpen={isErrorModalOpen}
+        onClose={() => setIsErrorModalOpen(false)}
+        title="Submission Failed"
+      >
+        {errorModalMessage || "An error occurred while submitting the form."}
       </Modal>
 
       {/* Toast */}

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -52,7 +52,7 @@ const HeroSection: React.FC = () => {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2 }}
-            className="text-lg sm:text-xl text-text-secondary leading-relaxed max-w-2xl mx-auto py-8"
+            className="text-lg sm:text-xl text-text-secondary leading-relaxed sm:max-w-2xl max-w-xs mx-auto py-8"
           >
             Make It Look transforms bold ideas into elegant digital and print
             experiences — designed to captivate, inspire, and convert.


### PR DESCRIPTION
## Summary
- handle web3 submission failures with a new modal
- show message from the server in the new modal

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a72d0440832dafed8751c3f4eb5b